### PR TITLE
Added Icon {SkullOwner:""} and built-in {exactX}, Y and Z

### DIFF
--- a/src/main/java/com/kerbybit/chattriggers/gui/IconHandler.java
+++ b/src/main/java/com/kerbybit/chattriggers/gui/IconHandler.java
@@ -4,9 +4,12 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemSkull;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagString;
 import net.minecraft.potion.Potion;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 
@@ -76,20 +79,32 @@ public class IconHandler {
                 if (get_name.contains(":")) {
                     get_final_name = get_name.substring(0, get_name.indexOf(":"));
                     try {
-                        meta = Integer.parseInt(get_name.substring(get_name.indexOf(":")+1));
+                    	if (get_name.contains("{")) {
+							meta = Integer.parseInt(get_name.substring(get_name.indexOf(":")+1, get_name.indexOf("{")));
+						} else {
+							meta = Integer.parseInt(get_name.substring(get_name.indexOf(":")+1));
+						}
                     } catch (NumberFormatException e) {
                         meta = 0;
                         color = get_name.substring(get_name.indexOf(":")+1);
                     }
                 }
+
+                String skullOwner = null;
+                if (get_name.contains("{SkullOwner:\"")) {
+                	skullOwner = get_name.substring(get_name.indexOf("{SkullOwner:\"") + 13, get_name.indexOf("\"}"));
+				}
+
                 Item item = Item.getByNameOrId(get_final_name);
                 ItemStack itemStack = new ItemStack(item,1, meta);
+
                 NBTTagCompound nbt = itemStack.getTagCompound();
-                if (nbt==null) {
+                if (nbt == null) {
                     nbt = new NBTTagCompound();
                     itemStack.setTagCompound(nbt);
                 }
-                if (color!=null) {
+
+                if (color != null) {
                     try {
                         NBTTagCompound colorCompound = new NBTTagCompound();
                         colorCompound.setInteger("color", Integer.parseInt(color.substring(1)));
@@ -98,6 +113,12 @@ public class IconHandler {
                         //do nothing
                     }
                 }
+
+                if (skullOwner != null && item instanceof ItemSkull) {
+                	nbt.setTag("SkullOwner", new NBTTagString(skullOwner));
+					itemStack.getItem().updateItemStackNBT(nbt);
+				}
+
                 if (item != null) {
                     drawItemIcon(x + Minecraft.getMinecraft().fontRendererObj.getStringWidth(before_value), y-4, itemStack);
                     return drawIcons(input.replace("{icon["+get_name+"]}", "    "), x, y);

--- a/src/main/java/com/kerbybit/chattriggers/triggers/BuiltInStrings.java
+++ b/src/main/java/com/kerbybit/chattriggers/triggers/BuiltInStrings.java
@@ -332,6 +332,15 @@ public class BuiltInStrings {
         if (TMP_e.contains("{exactZ}")) {
             TMP_e = createDefaultString("exactZ", Minecraft.getMinecraft().thePlayer.posZ+"", TMP_e, isAsync);
         }
+		if (TMP_e.contains("{motionX}")) {
+			TMP_e = createDefaultString("motionX", Minecraft.getMinecraft().thePlayer.motionX + "", TMP_e, isAsync);
+		}
+		if (TMP_e.contains("{motionY}")) {
+			TMP_e = createDefaultString("motionX", Minecraft.getMinecraft().thePlayer.motionY + "", TMP_e, isAsync);
+		}
+		if (TMP_e.contains("{motionZ}")) {
+			TMP_e = createDefaultString("motionX", Minecraft.getMinecraft().thePlayer.motionZ + "", TMP_e, isAsync);
+		}
         if (TMP_e.contains("{fps}")) {
             TMP_e = createDefaultString("fps", Minecraft.getDebugFPS()+"", TMP_e, isAsync);
         }
@@ -522,6 +531,15 @@ public class BuiltInStrings {
 					jsonString += "\"entity\":{";
 					jsonString += "\"name\":\"" + entity.getName() + "\",";
 					jsonString += "\"displayName\":\"" + entity.getCustomNameTag() + EnumChatFormatting.RESET + "\",";
+					jsonString += "\"xPos\":" + entity.getPosition().getX() + ",";
+					jsonString += "\"yPos\":" + entity.getPosition().getY() + ",";
+					jsonString += "\"zPos\":" + entity.getPosition().getZ() + ",";
+					jsonString += "\"xPosExact\":" + entity.posX + ",";
+					jsonString += "\"yPosExact\":" + entity.posY + ",";
+					jsonString += "\"zPosExact\":" + entity.posZ + ",";
+					jsonString += "\"motionX\":" + entity.motionX + ",";
+					jsonString += "\"motionY\":" + entity.motionY + ",";
+					jsonString += "\"motionZ\":" + entity.motionZ + ",";
 					jsonString += "\"metadata\":{";
 
 					for (String key : tags.getKeySet()) {

--- a/src/main/java/com/kerbybit/chattriggers/triggers/BuiltInStrings.java
+++ b/src/main/java/com/kerbybit/chattriggers/triggers/BuiltInStrings.java
@@ -323,6 +323,15 @@ public class BuiltInStrings {
         if (TMP_e.contains("{coordz}") || TMP_e.contains("{z}")) {
             TMP_e = createDefaultString("coordz", "z", Math.round(Minecraft.getMinecraft().thePlayer.posZ)+"", TMP_e, isAsync);
         }
+        if (TMP_e.contains("{exactX}")) {
+            TMP_e = createDefaultString("exactX", Minecraft.getMinecraft().thePlayer.posX+"", TMP_e, isAsync);
+        }
+        if (TMP_e.contains("{exactY}")) {
+            TMP_e = createDefaultString("exactY", Minecraft.getMinecraft().thePlayer.posY+"", TMP_e, isAsync);
+        }
+        if (TMP_e.contains("{exactZ}")) {
+            TMP_e = createDefaultString("exactZ", Minecraft.getMinecraft().thePlayer.posZ+"", TMP_e, isAsync);
+        }
         if (TMP_e.contains("{fps}")) {
             TMP_e = createDefaultString("fps", Minecraft.getDebugFPS()+"", TMP_e, isAsync);
         }
@@ -506,7 +515,8 @@ public class BuiltInStrings {
 			try {
 				if (mop.typeOfHit == MovingObjectPosition.MovingObjectType.ENTITY) {
 					Entity entity = mop.entityHit;
-					NBTTagCompound nbt = entity.getEntityData();
+					NBTTagCompound tags = new NBTTagCompound();
+					entity.writeToNBT(tags);
 
 					jsonString = "{\"type\":\"entity\",";
 					jsonString += "\"entity\":{";
@@ -514,8 +524,8 @@ public class BuiltInStrings {
 					jsonString += "\"displayName\":\"" + entity.getCustomNameTag() + EnumChatFormatting.RESET + "\",";
 					jsonString += "\"metadata\":{";
 
-					for (String key : nbt.getKeySet()) {
-						jsonString += "\"" + key + "\":\"" + nbt.getTag(key).toString() + "\",";
+					for (String key : tags.getKeySet()) {
+						jsonString += "\"" + key + "\":\"" + tags.getTag(key).toString() + "\",";
 					}
 
 					if (jsonString.endsWith(",")) jsonString = jsonString.substring(0, jsonString.length() - 1);

--- a/src/main/java/com/kerbybit/chattriggers/triggers/BuiltInStrings.java
+++ b/src/main/java/com/kerbybit/chattriggers/triggers/BuiltInStrings.java
@@ -146,22 +146,22 @@ public class BuiltInStrings {
         }
         if (TMP_e.contains("{server}")) {
             String current_server;
-            if (Minecraft.getMinecraft().isSingleplayer()) {current_server = "SinglePlayer";}
-            else {current_server = Minecraft.getMinecraft().getCurrentServerData().serverName;}
+            if (Minecraft.getMinecraft().isSingleplayer()) current_server = "SinglePlayer";
+            else current_server = Minecraft.getMinecraft().getCurrentServerData().serverName;
 
             TMP_e = createDefaultString("server", current_server, TMP_e, isAsync);
         }
         if (TMP_e.contains("{serverMOTD}")) {
             String returnString;
-            if (Minecraft.getMinecraft().isSingleplayer()) {returnString = "Single Player world";}
-            else {returnString = Minecraft.getMinecraft().getCurrentServerData().serverMOTD;}
+            if (Minecraft.getMinecraft().isSingleplayer()) returnString = "Single Player world";
+            else returnString = Minecraft.getMinecraft().getCurrentServerData().serverMOTD;
 
             TMP_e = createDefaultString("serverMOTD", returnString, TMP_e, isAsync);
         }
         if (TMP_e.contains("{serverIP}")) {
             String returnString;
-            if (Minecraft.getMinecraft().isSingleplayer()) {returnString = "localhost";}
-            else {returnString = Minecraft.getMinecraft().getCurrentServerData().serverIP;}
+            if (Minecraft.getMinecraft().isSingleplayer()) returnString = "localhost";
+            else returnString = Minecraft.getMinecraft().getCurrentServerData().serverIP;
 
             TMP_e = createDefaultString("serverIP", returnString, TMP_e, isAsync);
         }
@@ -314,13 +314,13 @@ public class BuiltInStrings {
         if (TMP_e.contains("{inchat}")) {
             TMP_e = createDefaultString("inchat", Minecraft.getMinecraft().ingameGUI.getChatGUI().getChatOpen() + "", TMP_e, isAsync);
         }
-        if (TMP_e.contains("{coordx}") || TMP_e.contains("{x}")) {
+        if (TMP_e.contains("{coordX}") || TMP_e.contains("{x}")) {
             TMP_e = createDefaultString("coordx", "x", Math.round(Minecraft.getMinecraft().thePlayer.posX)+"", TMP_e, isAsync);
         }
-        if (TMP_e.contains("{coordy}") || TMP_e.contains("{y}")) {
+        if (TMP_e.contains("{coordY}") || TMP_e.contains("{y}")) {
             TMP_e = createDefaultString("coordy", "y", Math.round(Minecraft.getMinecraft().thePlayer.posY)+"", TMP_e, isAsync);
         }
-        if (TMP_e.contains("{coordz}") || TMP_e.contains("{z}")) {
+        if (TMP_e.contains("{coordZ}") || TMP_e.contains("{z}")) {
             TMP_e = createDefaultString("coordz", "z", Math.round(Minecraft.getMinecraft().thePlayer.posZ)+"", TMP_e, isAsync);
         }
         if (TMP_e.contains("{exactX}")) {

--- a/src/main/java/com/kerbybit/chattriggers/triggers/StringFunctions.java
+++ b/src/main/java/com/kerbybit/chattriggers/triggers/StringFunctions.java
@@ -483,6 +483,8 @@ public class StringFunctions {
 			case "ABSOLUTE":
 			case "ABS":
 				return trimNumber(Math.abs(stringValueNumber));
+			case "SQRT":
+				return trimNumber(Math.sqrt(stringValueNumber));
         }
 
         return null;

--- a/src/main/java/com/kerbybit/chattriggers/triggers/StringFunctions.java
+++ b/src/main/java/com/kerbybit/chattriggers/triggers/StringFunctions.java
@@ -384,11 +384,11 @@ public class StringFunctions {
             case "LTE":
             case "<=":
                 return trimBool(stringValueNumber <= argsValueNumber);
-            case "GREATORTHAN":
+            case "GREATERTHAN":
             case "GT":
             case ">":
                 return trimBool(stringValueNumber > argsValueNumber);
-            case "GREATORTHANOREQUALTO":
+            case "GREATERTHANOREQUALTO":
             case "GTE":
             case ">=":
                 return trimBool(stringValueNumber >= argsValueNumber);


### PR DESCRIPTION
Icons with skull items can now specify the owner.
Ex. {icon[skull:3{SkullOwner:"FalseHonesty"}]}
Also added built-in strings with exact, decimal placed coordinates {exactX} Y, and Z